### PR TITLE
Change highlighter usage to rouge for github pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ timezone: Europe/Brussels
 # github overrides some values as follows
 safe: true
 lsi: false
-highlighter: true
+rouge: true
 
 
 redcloth:


### PR DESCRIPTION
Usage rouge as suggested by github pages warning when building site.