### PR TITLE
Fix link to MOGUL in 1.4 documentation page

### DIFF
--- a/mozart-v1/doc-1.4.0/index.html
+++ b/mozart-v1/doc-1.4.0/index.html
@@ -160,7 +160,7 @@ p.h2a { font-size:12pt; color:steelblue; text-align: left; }
                          >Contributed Libraries</a>,
                       <a href="add-ons/" class=h2
                          >Add-ons</a></dt>
-                  <dt><a href="http://www.mozart-oz.org/mogul/" class=h2
+                  <dt><a href="../../mogul/index.html" class=h2
 			 >MOzart Global User Library (MOGUL)</a></dt>
                   <dt><a href="ozdoc/index.html" class=h2
                          >Oz Documentation DTD</a></dt>


### PR DESCRIPTION
Link to MOGUL in the 1.4 documentation points to the old domain.