### PR TITLE
Fix: Added missing space characters

### DIFF
--- a/history/index.md
+++ b/history/index.md
@@ -91,6 +91,6 @@ Past board members include:
 ### Documentation Comics
 The comics used in the Mozart documentation have been done by Andreas Schoch.
 
-###The Mozart Logo
+### The Mozart Logo
 
 The Mozart logo was designed by Christian Lindig.

--- a/publications/index.md
+++ b/publications/index.md
@@ -142,7 +142,7 @@ Jump to:
 
 
 
-##Distribution <a name="distribution" />
+## Distribution <a name="distribution" />
 
 - Géry Debongnie, Raphaël Collet, Sébastien Doeraene, and Peter Van Roy. [Modular Fault Handling in a Network-Transparent Language](http://www.info.ucl.ac.be/%7Epvr/weh2012_cr.pdf), 5th International Workshop on Exception Handling (WEH 12), Zurich, Switzerland, June 9, 2012.
 - Boris Mejías. [Beernet: A Relaxed Approach to the Design of Scalable Systems with Self-Managing Behaviour and Transactional Robust Storage](http://www.info.ucl.ac.be/%7Epvr/beernet-phd-cl.pdf), Ph.D. dissertation, ICTEAM Institute (formerly Department of Computing Science and Engineering), Université catholique de Louvain, Oct. 2010.

--- a/report-a-bug/index.md
+++ b/report-a-bug/index.md
@@ -5,7 +5,7 @@ title: Mozart bugs
 
 {% comment %} <!-- markdown formatted, see http://daringfireball.net/projects/markdown/basics --> {% endcomment %}
 
-#Report a Bug
+# Report a Bug
 
 Please submit Mozart 2 bug reports to [Github Issues](https://github.com/mozart/mozart2/issues).
 You need a Github account to use the system, but it is free to register.


### PR DESCRIPTION
The "The Mozart Logo" title of size 3 was not displayed correctly because of a missing space character after "###"